### PR TITLE
Allow setting the Maven settings.xml file

### DIFF
--- a/tasks/maven_tasks.js
+++ b/tasks/maven_tasks.js
@@ -168,7 +168,6 @@ module.exports = function(grunt) {
     grunt.util.spawn({ cmd: 'mvn', args: args, opts: {stdio: 'inherit'} }, function(err, result, code) {
       if (err) {
         grunt.verbose.or.write(msg);
-        grunt.log.error().error(args);
         grunt.log.error().error('Failed to install to maven');
       } else {
         grunt.verbose.ok();


### PR DESCRIPTION
Hello, this is a small patch to allow setting the settings.xml file from your Gruntfile.js. This is for build environments like Cloudbees Jenkins where you need to specify an alternative location for the settings.xml file for your authentication parameters. We are using it like this (example from our Gruntfile.js):

```
    maven: {
      options: {
        groupId: 'com.group.name',
        settingsXml: process.env.MVN_SETTINGSXML
      },
```
