### PR TITLE
Adds support for jar files (in order to create webjars)

### DIFF
--- a/tasks/maven_tasks.js
+++ b/tasks/maven_tasks.js
@@ -111,8 +111,7 @@ module.exports = function(grunt) {
   }
 
   function getFileNameBase(options) {
-	  return options.artifactId + '-' + options.version
-      + (options.classifier ? '-' + options.classifier : '');
+      return options.artifactId + '-' + options.version + (options.classifier ? '-' + options.classifier : '');
   }
 
   function guaranteeFileName(options) {
@@ -154,7 +153,7 @@ module.exports = function(grunt) {
     args.push('-Dpackaging='    + options.packaging);
     args.push('-Dversion='      + options.version);
     if (options.classifier) {
-    	args.push('-Dclassifier=' + options.classifier);
+        args.push('-Dclassifier=' + options.classifier);
     }
     // The lack of a space after the -s is critical
     // otherwise the path will be processed by maven incorrectly.
@@ -190,7 +189,7 @@ module.exports = function(grunt) {
     args.push('-Dpackaging='    + options.packaging);
     args.push('-Dversion='      + options.version);
     if (options.classifier) {
-    	args.push('-Dclassifier=' + options.classifier);
+        args.push('-Dclassifier=' + options.classifier);
     }
     args.push('-Durl='          + options.url);
     if (options.repositoryId) {


### PR DESCRIPTION
See http://webjars.org. Create a webjar like this:

```
var artifactOptions = {
    groupId: 'com.example',
    artifactId: 'example-artifact',
    version: '1.0-SNAPSHOT'
};

maven: {
        options: artifactOptions,
        install: {
            options: {
                goal: 'install',
                packaging: 'zip',
                type: 'jar',
                injectDestFolder: false,
                url: 'file://a-repo'
            },
            expand: true,
            cwd: 'target/',
            src: ['**/*.*'],
            //dest: '/META-INF/resources/webjars/' + artifactOptions.artifactId + '/' + artifactOptions.version
        }
    }
```

Also a small refactoring to avoid duplicate code. Does not add unit tests for the jar part (that would require some work restructuring the unit test approach)
