### PR TITLE
Add capability of targeting directly maven:package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ grunt.loadNpmTasks('grunt-maven-tasks');
 
 If no goal is specified, the goal will be set to the target name. This means that the target name must be one of `install`, `deploy` or `release`. For more flexibility with the naming of your targets, and/or having multiple targets with the same goal, specify the goal explicitly.
 
+### package
+
+_Run the `grunt package` task with the `goal` option set to `package`._
+
+This tasks packages an artifact.
+
 ### install
 
 _Run the `grunt maven` task with the `goal` option set to `install`._
@@ -183,6 +189,12 @@ Running `grunt maven:release` will deploy the artifact to the `release-repo` fol
 grunt.initConfig({
   maven: {
     options: { groupId: 'com.example' },
+    'package': {
+      options: {
+        goal: 'package'
+      },
+      src: [ '**', '!node_modules/**' ]
+    },
     deploy: {
       options: {
         goal: 'deploy',
@@ -200,6 +212,7 @@ grunt.initConfig({
   }
 })
 
+grunt.registerTask('package', [ 'clean', 'test', 'maven:package' ]);
 grunt.registerTask('deploy', [ 'clean', 'test', 'maven:deploy' ]);
 grunt.registerTask('release', [ 'clean', 'test', 'maven:release' ]);
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-maven-tasks",
   "description": "Grunt plugin to deploy a file to a maven repository",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "homepage": "https://github.com/smh/grunt-maven-tasks",
   "author": {
     "name": "Stein Martin Hustad",

--- a/tasks/maven_tasks.js
+++ b/tasks/maven_tasks.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
     configureDestination(options, task);
     configureMaven(options, task);
 
-    grunt.task.run('maven:package');
+    grunt.task.run('mvn:package');
   }
 
   function install(task, pkg) {
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
     configureDestination(options, task);
     configureMaven(options, task);
 
-    grunt.task.run('maven:package',
+    grunt.task.run('mvn:package',
       'maven:install-file');
   }
 
@@ -84,7 +84,7 @@ module.exports = function(grunt) {
     configureDestination(options, task);
     configureMaven(options, task);
 
-    grunt.task.run('maven:package',
+    grunt.task.run('mvn:package',
       'maven:deploy-file');
   }
 
@@ -122,7 +122,7 @@ module.exports = function(grunt) {
 
     grunt.task.run(
       'maven:version:' + options.version,
-      'maven:package',
+      'mvn:package',
       'maven:deploy-file',
       'maven:version:' + options.nextVersion + ':deleteTag'
     );
@@ -155,16 +155,19 @@ module.exports = function(grunt) {
   }
 
   function configureMaven(options, task) {
-    grunt.config.set('maven.package.options', { archive: options.file, mode: options.packaging });
+    grunt.config.set('maven.package.options', { archive: options.file, mode: options.packaging, type: options.type });
     grunt.config.set('maven.package.files', task.files);
     grunt.config.set('maven.deploy-file.options', options);
     grunt.config.set('maven.install-file.options', options);
   }
 
-  grunt.registerTask('maven:package', function() {
+  grunt.registerTask('mvn:package', function() {
     var compress = require('grunt-contrib-compress/tasks/lib/compress')(grunt);
     compress.options = grunt.config('maven.package.options');
     compress.tar(grunt.config('maven.package.files'), this.async());
+
+    renameForKnownPackageTypeArtifacts(compress.options.archive,
+	(compress.options.type === 'war' || compress.options.type === 'jar') ? compress.options.type : compress.options.packaging);
   });
 
   grunt.registerTask('maven:install-file', function() {

--- a/tasks/maven_tasks.js
+++ b/tasks/maven_tasks.js
@@ -36,11 +36,27 @@ module.exports = function(grunt) {
       deploy(this, pkg);
     } else if (options.goal === 'install') {
       install(this, pkg);
+    } else if (options.goal === 'package') {
+      fpackage(this, pkg);
     } else if (options.goal === 'release') {
       requireOptionProps(options, ['url']);
       release(this, pkg, version, mode);
     }
   });
+  
+  function fpackage(task, pkg) {
+    var options = task.options({
+      artifactId: pkg.name,
+      version: pkg.version,
+      packaging: 'zip'
+    });
+
+    guaranteeFileName(options);
+    configureDestination(options, task);
+    configureMaven(options, task);
+
+    grunt.task.run('maven:package');
+  }
 
   function install(task, pkg) {
     var options = task.options({

--- a/test/package-test.js
+++ b/test/package-test.js
@@ -33,7 +33,7 @@ maven: {
   testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0' });
   testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0-SNAPSHOT', packaging: 'war' });
   testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0', packaging: 'zip' });
-  testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0-SNAPSHOT', packaging: 'tar.gz' });
+  testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0-SNAPSHOT', packaging: 'tgz' });
 });
 
 function testPackage(target, versionFile, pkg) {
@@ -65,8 +65,7 @@ function exec(command, fn) {
 }
 
 function verifyPackageFile(project, version, classifier, packaging, cb) {
-  var extension = (initConfig.maven.options.type === 'war' || initConfig.maven.options.type === 'jar') ? initConfig.maven.options.type : packaging;
-  var filename = project + '-' + version + (classifier? '-' + classifier : '') + '.' + extension;
+  var filename = project + '-' + version + (classifier? '-' + classifier : '') + '.' + getExtension(packaging, classifier, initConfig.maven.options.type);
 
   fs.readFile(path.join(projectDir, filename),
       function(err, data) {
@@ -75,6 +74,13 @@ function verifyPackageFile(project, version, classifier, packaging, cb) {
 	cb();
       });
 }
+
+// copy from maven_task
+function getExtension(packaging, classifier, type) {
+    if(classifier === 'javadoc' || classifier === 'sources') return 'zip';
+    return type ||  packaging || 'zip';
+  }
+
 
 function gruntfile(initConfig) {
   return 'var fs = require("fs");\n' +

--- a/test/package-test.js
+++ b/test/package-test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var rimraf = require('rimraf');
+var async = require('async');
+var semver = require('semver');
+var jszip = require('jszip');
+
+var chai = require('chai');
+chai.should();
+chai.use(require('chai-things'));
+
+var projectDir = path.join('/tmp', '/test-project');
+
+var initConfig = {
+maven: {
+  options: {
+      groupId: 'test.project', 
+      type: 'war'
+    },
+    'package': {
+      options: {
+        goal: 'package',
+	src: [ '**', '!node_modules/**' ],
+      }
+    }
+  }
+};
+
+// test various package configurations
+['package'].forEach(function(target) {
+  testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0' });
+  testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0-SNAPSHOT', packaging: 'war' });
+  testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0', packaging: 'zip' });
+  testPackage(target, 'package.json', { name: 'test-project', version: '1.0.0-SNAPSHOT', packaging: 'tar.gz' });
+});
+
+function testPackage(target, versionFile, pkg) {
+  describe(target + ' - ' + pkg.version + ':' + pkg.classifier + ' -', function() {
+    before(function(done) {
+      async.series([
+        function(cb) { setupGruntProject(versionFile, pkg, initConfig, cb); },
+        function(cb) { exec('grunt maven:' + target + ' --no-color', done); }
+      ], done);
+    });
+    after(function(done) {
+      rimraf(projectDir, done);
+    });
+
+    it('should create a package file', function(done) {
+      verifyPackageFile(pkg.name, pkg.version, pkg.classifier, pkg.packaging, done);
+    });
+  });
+}
+
+function exec(command, fn) {
+  require('child_process').exec(command, { cwd: projectDir }, function(err, stdout, stderr) {
+    if (err) {
+      if (stdout) { err.message += '\n' + stdout; }
+      if (stderr) { err.message += '\n' + stderr; }
+    }
+    fn(err, stdout, stderr);
+  });
+}
+
+function verifyPackageFile(project, version, classifier, packaging, cb) {
+  var extension = (initConfig.maven.options.type === 'war' || initConfig.maven.options.type === 'jar') ? initConfig.maven.options.type : packaging;
+  var filename = project + '-' + version + (classifier? '-' + classifier : '') + '.' + extension;
+
+  fs.readFile(path.join(projectDir, filename),
+      function(err, data) {
+	if (err) { throw err; }
+	var zip = new jszip(data);
+	cb();
+      });
+}
+
+function gruntfile(initConfig) {
+  return 'var fs = require("fs");\n' +
+         'module.exports = function(grunt) {\n' +
+         '  grunt.initConfig(' + JSON.stringify(initConfig) + ');\n' +
+         '  grunt.loadTasks("' + path.join(__dirname, '..', 'tasks') + '")\n' +
+         '};\n';
+}
+
+function setupGruntProject(versionFile, pkg, initConfig, fn) {
+  var commands = [
+    function(cb) { rimraf(projectDir, cb); },
+    function(cb) { fs.mkdir(projectDir, cb); },
+    function(cb) { fs.writeFile(path.join(projectDir, versionFile), JSON.stringify(pkg), cb); },
+    function(cb) { fs.writeFile(path.join(projectDir, 'Gruntfile.js'), gruntfile(initConfig), cb); },
+    function(cb) { fs.writeFile(path.join(projectDir, 'somefile.txt'), 'somedata', cb); },
+    function(cb) { exec('ln -s ' + path.join(__dirname, '..', 'node_modules'), cb); }
+  ];
+  async.series(commands, fn);
+}
+

--- a/test/zip-test.js
+++ b/test/zip-test.js
@@ -46,10 +46,9 @@ describe('Test that correct access bits are set', function() {
   });
   after(function(done) {
     rimraf(projectDir, done);
-    //done();
   });
   it('should not destroy file access bits', function(done) {
-    verifyZipFile("test-project-1.0.0-SNAPSHOT", done);
+    verifyZipFile(pkg, done);
   });
 });
 
@@ -64,16 +63,18 @@ function exec(command, fn) {
   });
 }
 
-function verifyZipFile(project, cb) {
-  fs.readFile(path.join(projectDir, project + ".zip"),
-	      function(err, data) {
-		if (err) throw err;
-		var zip = new jszip(data);
-		var access=(zip.files[project + '/' + relScriptFile].unixPermissions & 511).toString(8);
-	        access.should.equal('755'); // When (the correct) grunt-contrib-compress 0.7 or higher is used.
-		//access.should.equal('0'); // When grunt-contrib-compress 0.4 is used.
-		cb();
-	      });
+function verifyZipFile(pkg, cb) {
+  var deploy = JSON.parse(fs.readFileSync(path.join(projectDir, pkg.name + '-install.json')));
+
+  fs.readFile(path.join(projectDir, deploy.file),
+      function(err, data) {
+	if (err) throw err;
+	var zip = new jszip(data);
+	var access=(zip.files[pkg.name +'-'+pkg.version + '/' + relScriptFile].unixPermissions & 511).toString(8);
+        access.should.equal('755'); // When (the correct) grunt-contrib-compress 0.7 or higher is used.
+	//access.should.equal('0'); // When grunt-contrib-compress 0.4 is used.
+	cb();
+      });
 }
 
 


### PR DESCRIPTION
Not sure if properly done but I need to only invoque maven:package and global configuration need to be done.

Because of my doubts I did not update the doc. One simple concern could be the reserved word 'package' that cannot be used in Gruntfile.js to declare the tasks.